### PR TITLE
Add support quoted php conf value

### DIFF
--- a/ApacheConf.tmLanguage
+++ b/ApacheConf.tmLanguage
@@ -721,7 +721,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b(php_value|php_flag|php_admin_value|php_admin_flag)\b(\s+(.+?)(\s+(.+?))?)?\s</string>
+			<string>\b(php_value|php_flag|php_admin_value|php_admin_flag)\b(\s+(.+?)(\s+(".+?"|.+?))?)?\s</string>
 		</dict>
 
 		<dict>


### PR DESCRIPTION
It is necessary, if the value contains spaces