### PR TITLE
More common integer scope

### DIFF
--- a/ApacheConf.tmLanguage
+++ b/ApacheConf.tmLanguage
@@ -820,7 +820,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>constant.integer.apacheconf</string>
+					<string>constant.numeric.integer.decimal.apacheconf</string>
 				</dict>
 			</dict>
 			<key>match</key>


### PR DESCRIPTION
This commit renames the integer scope to `constant.numeric.integer` to have a better chance to have it addressed by color schemes as it is the common scope proposed for numeric constants according to ST's scope naming guidelines.